### PR TITLE
Feature/dashboard tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Local config files
+config/config.js
+

--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@ body {
     font-family: Arial, sans-serif;
 }
 
-.card-one {
+.card {
     position: relative;
     width: 350px;
     height: 550px;
@@ -187,12 +187,17 @@ body {
 
 .slider-track {
     display: flex;
-    transition: transform 0.35s ease;
+    transition: transform 0.3s ease;
     will-change: transform;
+    cursor: grab;
+    user-select: none;
+}
+.slider-track:active {
+    cursor: grabbing;
 }
 
 /* Make each card take full slider width */
-.slider-track .card-one {
+.slider-track .card {
     flex: 0 0 350px; /* Match slider width */
     margin: 0; 
 }

--- a/css/style.css
+++ b/css/style.css
@@ -177,3 +177,38 @@ body {
 
 /* Hide agenda when it's a rest day */
 .session-info.rest + .session-agenda { display: none; }
+
+/*Slider shellet*/
+.slider {
+    width: 350px;
+    overflow: hidden;
+    margin: 0 auto;
+}
+
+.slider-track {
+    display: flex;
+    transition: transform 0.35s ease;
+    will-change: transform;
+}
+
+/* Make each card take full slider width */
+.slider-track .card-one {
+    flex: 0 0 350px; /* Match slider width */
+    margin: 0; 
+}
+
+/* Dots */
+.dots {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  border: none; cursor: pointer;
+  background: #cbd5e1;
+}
+
+.dot.active { background: #0b6ef6; }

--- a/css/style.css
+++ b/css/style.css
@@ -52,7 +52,7 @@ body {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
-#session-title {
+.session-title {
     font-size: 16px;
     font-weight: 700;
     color: #222;
@@ -61,14 +61,14 @@ body {
     letter-spacing: 0.5px;
 }
 
-#session-time {
+.session-time {
     font-size: 18px;
     font-weight: 600;
     color: #c40d9c;
     margin-bottom: 6px;
 }
 
-#session-location {
+.session-location {
     font-size: 14px;
     color: #555;
     margin-bottom: 14px;

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,35 +1,72 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard</title>
-    <link rel="stylesheet" href="css/style.css">
-</head>
-<body>
-    <div class="card-one">
-       <div class="weather-widget" aria-live="polite">Loading...</div>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    <div class="slider">
+      <div class="slider-track" id="sliderTrack">
+        <!-- Card 0: TODAY (original card) -->
+        <div class="card-one">
+          <div class="weather-widget" aria-live="polite">Loading...</div>
 
-       <div class="date-display" id="date" aria-live="polite">
-         Thu, Apr 24
-       </div>
-       <div class="session-info">
-        <h3 id="session-title"></h3>
-        <p id="session-time"></p>
-        <p id="session-location"></p>
-        <div class="session-action" id="sessionAction">
-            <button id="join-button" type="button">I'm in</button>
-        </div>
-       </div>
+          <div class="date-display" id="date" aria-live="polite">
+            Thu, Apr 24
+          </div>
 
-       <!-- Session Agenda / Description -->
-        <section class="session-agenda" id="sessionAgenda">
-            <h4 class="agenda-title">Agenda</h4>
+          <div class="session-info">
+            <h3 id="session-title"></h3>
+            <p id="session-time"></p>
+            <p id="session-location"></p>
+            <div class="session-action" id="sessionAction">
+              <button id="join-button" type="button">I'm in</button>
+            </div>
+          </div>
+
+          <!-- Session Agenda / Description -->
+          <div class="session-agenda" id="sessionAgenda">
+            <div class="agenda-title">Agenda</div>
             <ul class="agenda-list" id="agendaList"></ul>
             <p class="agenda-notes" id="agendaNotes"></p>
-        </section>
-            
+          </div>
+        </div>
+        <!-- /card-one (today) -->
+
+        <!-- Card 1: TOMORROW -->
+        <div class="card-one">
+          <div class="weather-widget" aria-live="polite">Loading...</div>
+
+          <div class="date-display" id="date-1" aria-live="polite">--</div>
+
+          <div class="session-info" id="session-1">
+            <h3 id="session-title-1"></h3>
+            <p id="session-time-1"></p>
+            <p id="session-location-1"></p>
+            <div class="session-action" id="sessionAction-1">
+              <button id="join-button-1" type="button">I'm in</button>
+            </div>
+          </div>
+
+          <div class="session-agenda" id="sessionAgenda-1">
+            <div class="agenda-title">Agenda</div>
+            <ul class="agenda-list" id="agendaList-1"></ul>
+            <p class="agenda-notes" id="agendaNotes-1"></p>
+          </div>
+        </div>
+        <!-- /card-one (tomorrow) -->
+      </div>
+      <!-- /slider-track -->
+
+      <!-- Pagination dots (sibling of slider-track) -->
+      <div class="dots">
+        <button class="dot active" data-slide="0" aria-label="Today"></button>
+        <button class="dot" data-slide="1" aria-label="Tomorrow"></button>
+      </div>
     </div>
+
     <script src="js/script.js"></script>
-</body>
+  </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -87,6 +87,7 @@
       </div>
     </div>
 
+    <script src="config/config.js"></script>
     <script src="js/script.js"></script>
   </body>
 </html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -18,20 +18,20 @@
             Thu, Apr 24
           </div>
 
-          <div class="session-info">
-            <h3 id="session-title"></h3>
-            <p id="session-time"></p>
-            <p id="session-location"></p>
-            <div class="session-action" id="sessionAction">
-              <button id="join-button" type="button">I'm in</button>
+          <div class="session-info" id="session-0">
+            <h3 class="session-title" id="session-title-0"></h3>
+            <p class="session-time" id="session-time-0"></p>
+            <p class="session-location" id="session-location-0"></p>
+            <div class="session-action" id="sessionAction-0">
+              <button id="join-button-0" type="button">I'm in</button>
             </div>
           </div>
 
           <!-- Session Agenda / Description -->
-          <div class="session-agenda" id="sessionAgenda">
+          <div class="session-agenda" id="sessionAgenda-0">
             <div class="agenda-title">Agenda</div>
-            <ul class="agenda-list" id="agendaList"></ul>
-            <p class="agenda-notes" id="agendaNotes"></p>
+            <ul class="agenda-list" id="agendaList-0"></ul>
+            <p class="agenda-notes" id="agendaNotes-0"></p>
           </div>
         </div>
         <!-- /card-one (today) -->
@@ -43,9 +43,9 @@
           <div class="date-display" id="date-1" aria-live="polite">Sun, Sep 28</div>
 
           <div class="session-info" id="session-1">
-            <h3 id="session-title-1"></h3>
-            <p id="session-time-1"></p>
-            <p id="session-location-1"></p>
+            <h3 class="session-title" id="session-title-1"></h3>
+            <p class="session-time" id="session-time-1"></p>
+            <p class="session-location" id="session-location-1"></p>
             <div class="session-action" id="sessionAction-1">
               <button id="join-button-1" type="button">I'm in</button>
             </div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Dashboard</title>
-    <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/style.css"/>
   </head>
   <body>
     <div class="slider">
       <div class="slider-track" id="sliderTrack">
         
         <!-- Card 0: TODAY (original card) -->
-        <div class="card-one">
-          <div class="weather-widget" aria-live="polite">Loading...</div>
+        <div class="card">
+          <div class="weather-widget" id="weather-0" aria-live="polite">Loading...</div>
 
           <div class="date-display" id="date" aria-live="polite">
             Thu, Apr 24
@@ -34,11 +34,10 @@
             <p class="agenda-notes" id="agendaNotes-0"></p>
           </div>
         </div>
-        <!-- /card-one (today) -->
-
+        
         <!-- Card 1: TOMORROW -->
-        <div class="card-one">
-          <div class="weather-widget" id="weather-1">Loading...</div>
+        <div class="card">
+          <div class="weather-widget" id="weather-1" aria-live="polite">Loading...</div>
 
           <div class="date-display" id="date-1" aria-live="polite">Sun, Sep 28</div>
 
@@ -57,14 +56,34 @@
             <p class="agenda-notes" id="agendaNotes-1"></p>
           </div>
         </div>
-        <!-- /card-one (tomorrow) -->
+        <!-- Card 2: Day after tomorrow -->
+         <div class="card">
+          <div class="weather-widget" id="weather-2" aria-live="polite">Loading...</div>
+
+          <div class="date-display" id="date-2" aria-live="polite">Thu, Oct 2</div>
+
+          <div class="session-info" id="session-2">
+            <h3 class="session-title" id="session-title-2"></h3>
+            <p class="session-time" id="session-time-2"></p>
+            <p class="session-location" id="session-location-2"></p>
+            <div class="session-action" id="sessionAction-2">
+              <button id="join-button-2" type="button">I'm in</button>
+            </div>
+          </div>
+
+          <div class="session-agenda" id="sessionAgenda-2">
+            <div class="agenda-title">Agenda</div>
+            <ul class="agenda-list" id="agendaList-2"></ul>
+            <p class="agenda-notes" id="agendaNotes-2"></p>
+          </div>
+         </div>
       </div>
-      <!-- /slider-track -->
 
       <!-- Pagination dots (sibling of slider-track) -->
       <div class="dots">
         <button class="dot active" data-slide="0" aria-label="Today"></button>
         <button class="dot" data-slide="1" aria-label="Tomorrow"></button>
+        <button class="dot" data-slide="2" aria-label="dayAfterTomorrow"></button>
       </div>
     </div>
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -9,6 +9,7 @@
   <body>
     <div class="slider">
       <div class="slider-track" id="sliderTrack">
+        
         <!-- Card 0: TODAY (original card) -->
         <div class="card-one">
           <div class="weather-widget" aria-live="polite">Loading...</div>
@@ -37,9 +38,9 @@
 
         <!-- Card 1: TOMORROW -->
         <div class="card-one">
-          <div class="weather-widget" aria-live="polite">Loading...</div>
+          <div class="weather-widget" id="weather-1">Loading...</div>
 
-          <div class="date-display" id="date-1" aria-live="polite">--</div>
+          <div class="date-display" id="date-1" aria-live="polite">Sun, Sep 28</div>
 
           <div class="session-info" id="session-1">
             <h3 id="session-title-1"></h3>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 const apiKey = "01c96143ca17e347929f8cc6e0bcf4e5";
-const city = "Las Pinas,PH";
+const city = "Paranaque, PH";
 fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=metric`)
     .then(response => response.json())
     .then(data => {
@@ -18,7 +18,54 @@ fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}
         `;
     })
     .catch(error => console.error("Error fetching weather:", error));
+
+// --- Forecast weather for tomorrow (card 2) --- 
+    function updateTomorrowWeather () {
+        fetch(`https://api.openweathermap.org/data/2.5/forecast?q=${city}&appid=${apiKey}&units=metric`)
+        .then(response => response.json())
+        .then(data => {
+            // Tomorrow's date string
+            const tomorrow = new Date();
+            tomorrow.setDate(tomorrow.getDate() + 1);
+            const tomorrowStr = tomorrow.toISOString().split('T')[0];
+
+            // Find forecast closest to noon tomorrow
+            const forecastList = data.list;
+            let best = null;
+            let bestDiff = Infinity;
+            const target = new Date(`${tomorrowStr}T12:00:00`);
+
+            forecastList.forEach(item => {
+                const itemDate = new Date(item.dt_txt);
+                if (itemDate.toISOString().startsWith(tomorrowStr)) {
+                    const diff = Math.abs(itemDate - target);
+                    if (diff < bestDiff) {
+                        bestDiff = diff;
+                        best = item; 
+                    }
+                }
+            });
+
+            if (best) {
+                const temp = Math.round(best.main.temp);
+                const weather = best.weather[0].main;
+                const icon = best.weather[0].icon;
+                const location = `${data.city.name},${data.city.country}`;
+
+                const widget = document.getElementById('weather-1');
+                widget.innerHTML = `
+                <img src="https://openweathermap.org/img/wn/${icon}.png" alt="${weather}" />
+                <p>${temp}°C, ${weather}</p>
+                <small>${location}</small>
+                `;
+            }
+        })
+        .catch(error => console.error("Error fetching forecast:", error));
+    }
     
+    updateTomorrowWeather();
+        
+        
 /* Date Information */
     function updateDate() {
         const today = new Date();
@@ -27,25 +74,50 @@ fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}
     }
 
     updateDate();
+
+    // --- Tomorrow's date for the second card --- 
+    function updateTomorrowDate() {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+
+        const options = { weekday: 'short', month: 'short', day: 'numeric'};
+        document.getElementById("date-1").textContent = tomorrow.toLocaleDateString('en-US', options);
+    }
+
+    updateTomorrowDate();
     
 /* Session Information */
-    const session = {
-        isTrainingDay: true,        // Change this to true or false to toggle modes
-        title: "Training & Open Play",
-        time: "4:00 PM - 6:00 PM",
-        location: "The Village Sports Club",
-        restMessage: "No session today. Recover well and come back stronger! 💪",
-
-        // New: agenda & notes (admin-controllable later)
-        agenda: [
-            "Dynamic warm-up & mobility drills (10m)",
-            "First-touch rondos (20m)",
-            "Finishing drills (20m)",
-            "Small-sided games (30m)"
-        ],
-        notes: "Wear official kampilan training-kit."
-    };
-
+    const session = [
+        {
+            // card 0: today 
+            isTrainingDay: true,
+            title: "Training & Open Play",
+            time: "4:00 PM - 6:00 PM",
+            location: "The Village Sports Club",
+            restMessage: "No session today. Recover well and come back stronger! 💪",
+            agenda: [
+                "Dynamic warm-up & ball control",
+                "Passing drills",
+                "Scrimmage game",
+            ],
+            notes: "Wear official home kit."
+        },
+        {
+            // card 1: tomorrow 
+            isTrainingDay: true,  // Change this to true or false to toggle modes
+            title: "Training & Open Play",
+            time: "4:00 PM - 7:00 PM",
+            location: "BGC turf",
+            restMessage: "Rest day tomorrow. Focus on recovery! 🛌",
+            agenda: [
+                "Tactical positioning",
+                "Finishing practice",
+                "Small-sided games"
+            ],
+            notes: "Wear blue and white."
+        }
+    ];
+     
     /*Render function*/
     function renderAgenda(data) {
         const agendaWrap = document.getElementById("sessionAgenda");

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,7 @@
-const apiKey = "01c96143ca17e347929f8cc6e0bcf4e5";
+const apiKey = window.OWM_KEY || "";
+if (!apiKey) {
+    console.error('Missing API key: please set window.OWM_KEY in config/config.js');
+}
 const city = "Paranaque, PH";
 fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}&units=metric`)
     .then(response => response.json())
@@ -133,7 +136,7 @@ fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}
             title: "Training & Open Play",
             time: "4:00 PM - 6:00 PM",
             location: "The Village Sports Club",
-            restMessage: "No session today. Recover well and come back stronger! ðŸ’ª",
+            restMessage: "No session today. Recover well and come back stronger!",
             agenda: [
                 "Dynamic warm-up & ball control",
                 "Passing drills",
@@ -147,7 +150,7 @@ fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}
             title: "Training & Open Play",
             time: "4:00 PM - 7:00 PM",
             location: "BGC turf",
-            restMessage: "Rest day. Focus on recovery! ðŸ›Œ",
+            restMessage: "Rest day. Focus on recovery!",
             agenda: [
                 "Tactical positioning",
                 "Finishing practice",

--- a/js/script.js
+++ b/js/script.js
@@ -104,7 +104,7 @@ fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}
         },
         {
             // card 1: tomorrow 
-            isTrainingDay: true,  // Change this to true or false to toggle modes
+            isTrainingDay: false,  // Change this to true or false to toggle modes
             title: "Training & Open Play",
             time: "4:00 PM - 7:00 PM",
             location: "BGC turf",
@@ -119,93 +119,61 @@ fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}
     ];
      
     /*Render function*/
-    function renderAgenda(data) {
-        const agendaWrap = document.getElementById("sessionAgenda");
-        const list = document.getElementById("agendaList");
-        const notes = document.getElementById("agendaNotes");
-
-        if (!data.isTrainingDay) {
-            agendaWrap.style.display = "none"; // Hide agenda section on rest days
-            return;
-        }
-
-        // show agenda section 
-        agendaWrap.style.display = "";
-
-        // Populate agenda list
-        list.innerHTML = "";
-        if (Array.isArray(data.agenda) && data.agenda.length) {
-            data.agenda.forEach(item => {
-                const li = document.createElement("li");
-                li.textContent = item;
-                list.appendChild(li);
-            });
-        } else {
-            // graceful empty state
-            const li = document.createElement("li");
-            li.textContent = "Agenda to be announced.";
-            list.appendChild(li);
-        }
-        
-        // notes (optional)
-        notes.textContent = data.notes || "";
-    }
-
-
-    function renderSessionCard(data) {
-        const info = document.querySelector(".session-info");
-        const titleEl = document.getElementById("session-title");
-        const timeEl = document.getElementById("session-time");
-        const locEl = document.getElementById("session-location");
-        const action = document.getElementById("sessionAction");
+    function renderSessionCard(idx, data) {
+        const info = document.getElementById(`session-${idx}`);
+        const titleEl = document.getElementById(`session-title-${idx}`);
+        const timeEl = document.getElementById(`session-time-${idx}`);
+        const locEl = document.getElementById(`session-location-${idx}`);
+        const action = document.getElementById(`sessionAction-${idx}`);
+        const agendaList = document.getElementById(`agendaList-${idx}`);
+        const agendaNotes = document.getElementById(`agendaNotes-${idx}`);
+        const agendaWrap = document.getElementById(`sessionAgenda-${idx}`);
 
         if (data.isTrainingDay) {
-            // Training Mode 
             info.classList.remove("rest");
             titleEl.className = "";
             titleEl.textContent = data.title;
-            timeEl.textContent = data.time;
+            timeEl.textContent = data.time; 
             locEl.textContent = data.location;
-            action.style.display = "flex";    //show join button
+            action.style.display = "flex";
+
+            // agenda
+            agendaWrap.style.display = "";
+            agendaList.innerHTML = data.agenda.map(item => `<li>${item}</li>`).join("");
+            agendaNotes.textContent = data.notes || "";
         } else {
-            // Rest Mode
             info.classList.add("rest");
-            titleEl.className = "session-rest-title";
-            titleEl.textContent = "Rest Day";
+            titleEl.className ="session-rest-title";
+            titleEl.textContent ="Rest Day";
             timeEl.textContent = "";
             locEl.innerHTML = `<span class="session-rest-msg">${data.restMessage}</span>`;
-            action.style.display = "none";      //hide join button
+            action.style.display = "none";
+
+            // hide agenda
+            agendaWrap.style.display = "none";
         }
     }
 
-    renderSessionCard(session);
-    renderAgenda(session);
-
-
+    session.forEach((s, i) => renderSessionCard(i, s));
+    
     /* Join Button Functionality */
-    const joinButton = document.getElementById("join-button");
+    function wireJoinButton(idx) {
+        const btn = document.getElementById(`join-button-${idx}`);
+        if (!btn) return; 
 
-    // restore previous choice
-    const saved = localStorage.getItem('rsvp');
-    if (saved === 'in') setJoinState(true);
-
-    joinButton.addEventListener("click", () => {
-        const next = joinButton.textContent === "I'm in";
-        setJoinState(next);
-        localStorage.setItem('rsvp', next ? 'in' : 'out');
-    });
-
-    function setJoinState(going) {
-        if (going) {
-            joinButton.textContent = "Cancel";
-            joinButton.style.background = "#e63946"; // Change to red
-            joinButton.setAttribute('aria-pressed', 'true');
-        } else {
-            joinButton.textContent = "I'm in";
-            joinButton.style.background = "#0b6ef6" // Change back to original color
-            joinButton.setAttribute('aria-pressed', 'false');
-        }
+        btn.addEventListener("click", () => {
+            if (btn.textContent === "I'm in") {
+                btn.textContent = "Cancel";
+                btn.style.background = "#e63946"; // red
+            } else {
+                btn.textContent = "I'm in";
+                btn.style.background = "#0b6ef6"; // blue
+            }
+        });
     }
+
+    // Call it for each card
+    [0,1].forEach(idx => wireJoinButton(idx));
 
     // --- Minimal slider for 2 cards --- 
     const track = document.getElementById('sliderTrack');

--- a/js/script.js
+++ b/js/script.js
@@ -113,13 +113,41 @@ fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=${apiKey}
     /* Join Button Functionality */
     const joinButton = document.getElementById("join-button");
 
+    // restore previous choice
+    const saved = localStorage.getItem('rsvp');
+    if (saved === 'in') setJoinState(true);
+
     joinButton.addEventListener("click", () => {
-        if (joinButton.textContent === "I'm in") {
-            joinButton.textContent = "Cancel";
-            joinButton.style.background = "#e63946"; // Change to red
-        } else {
-            joinButton.textContent = "I'm in";
-            joinButton.style.background = "#0b6ef6"; // Change back to original color
-        }
+        const next = joinButton.textContent === "I'm in";
+        setJoinState(next);
+        localStorage.setItem('rsvp', next ? 'in' : 'out');
     });
 
+    function setJoinState(going) {
+        if (going) {
+            joinButton.textContent = "Cancel";
+            joinButton.style.background = "#e63946"; // Change to red
+            joinButton.setAttribute('aria-pressed', 'true');
+        } else {
+            joinButton.textContent = "I'm in";
+            joinButton.style.background = "#0b6ef6" // Change back to original color
+            joinButton.setAttribute('aria-pressed', 'false');
+        }
+    }
+
+    // --- Minimal slider for 2 cards --- 
+    const track = document.getElementById('sliderTrack');
+    const dots = Array.from(document.querySelectorAll('.dot'));
+    let currentSlide = 0; 
+
+    function slideTo(idx) {
+        currentSlide = idx;
+        track.style.transform = `translateX(-${idx * 350}px)`; // 350 = card width
+        dots.forEach((d, i) => d.classList.toggle('active', i === idx));
+    }
+
+    dots.forEach(d => {
+        d.addEventListener('click', () => slideTo(+d.dataset.slide));
+});
+
+  


### PR DESCRIPTION
## Summary
Adds second dashboard card (tomorrow) with forecast weather, improves slider UX (keyboard + drag), renders per-card agenda, and stabilizes join/cancel state per card.

## Changes
- Card 2 with date offset + forecast weather (noon snapshot)
- Weather widgets: today / tomorrow / day-after alignment
- Slider: keyboard navigation (←/→) + drag with threshold + dots sync
- Agenda rendering: data-driven for each card; hides on rest days
- Join button: isolated per card with localStorage persistence
- Style tweaks: card spacing, shadows, active dot state, accessibility attributes

## How to test
1. Open `dashboard.html` via Live Server
2. Verify:
   - Dots navigate between cards
   - Arrow keys navigate (←/→)
   - Dragging left/right snaps correctly at threshold
   - Today card shows current weather; next cards show forecast
   - “I’m in” toggles to “Cancel” per card; state persists on reload
   - Rest-day hides action/agenda
3. Resize to mobile and test drag on trackpad/touch if available.

## Screenshots
<img width="689" height="711" alt="{C5D37185-B5CA-4256-AC8C-9A39BC192D03}" src="https://github.com/user-attachments/assets/7d6a61e6-5431-4c34-9e1b-e2f93dd02963" />
<img width="514" height="663" alt="{D1A00B0E-F015-4DD5-B827-F3E8CA52018F}" src="https://github.com/user-attachments/assets/b2217cf7-6926-4a3a-b04d-930f57dca6a2" />


## Notes / Risks
- API key currently hard-coded for dev; see README for safe config.
- Forecast uses 3-hour blocks; we pick the closest to **12:00** local time.

## Checklist
- [x] Branch up to date with `main`
- [x] Lints/styles pass locally
- [x] No secrets committed
- [x] README updated
